### PR TITLE
Specify matrix type in metaedge_to_adjacency_matrix (#42)

### DIFF
--- a/hetmech/matrix.py
+++ b/hetmech/matrix.py
@@ -1,8 +1,8 @@
 from collections import OrderedDict
 
-import numpy
-
 import hetio.hetnet
+import numpy
+from scipy import sparse
 
 
 def get_node_to_position(graph, metanode):
@@ -18,7 +18,8 @@ def get_node_to_position(graph, metanode):
     return node_to_position
 
 
-def metaedge_to_adjacency_matrix(graph, metaedge, dtype=numpy.bool_):
+def metaedge_to_adjacency_matrix(graph, metaedge, dtype=numpy.bool_,
+                                 matrix_type=numpy.array):
     """
     Returns an adjacency matrix where source nodes are rows and target
     nodes are columns.
@@ -29,11 +30,20 @@ def metaedge_to_adjacency_matrix(graph, metaedge, dtype=numpy.bool_):
     source_nodes = list(get_node_to_position(graph, metaedge.source))
     target_node_to_position = get_node_to_position(graph, metaedge.target)
     shape = len(source_nodes), len(target_node_to_position)
-    adjacency_matrix = numpy.zeros(shape, dtype=dtype)
+    row, col, data = [], [], []
     for i, source_node in enumerate(source_nodes):
         for edge in source_node.edges[metaedge]:
-            j = target_node_to_position[edge.target]
-            adjacency_matrix[i, j] = 1
+            row.append(i)
+            col.append(target_node_to_position[edge.target])
+            data.append(1)
+    adjacency_matrix = sparse.csc_matrix((data, (row, col)), shape=shape,
+                                         dtype=dtype)
+    if matrix_type == numpy.array or matrix_type == numpy.ndarray:
+        adjacency_matrix = adjacency_matrix.toarray()
+    elif matrix_type == numpy.matrix:
+        adjacency_matrix = adjacency_matrix.todense()
+    else:
+        adjacency_matrix = matrix_type(adjacency_matrix)
     row_names = [node.identifier for node in source_nodes]
     column_names = [node.identifier for node in target_node_to_position]
     return row_names, column_names, adjacency_matrix


### PR DESCRIPTION
Enables creation of sparse matrices.

Closes https://github.com/greenelab/hetmech/issues/36